### PR TITLE
Removed id attribute - it's no longer used

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Each icon in Simple Icons has been annotated with a number of attributes and ele
     * `viewBox="0 0 24 24"`
   * The svg namespace.
     * `xmlns="http://www.w3.org/2000/svg"`
-* A title element with id attribute (Note the format).
+* A title element (Note the format).
   * `<title>Adobe Photoshop icon</title>`
 
 Here is _part of_ the svg for the Adobe Photoshop icon as an example:


### PR DESCRIPTION
<!--
Before opening your pull request, have a quick look at our contribution guidelines: https://github.com/simple-icons/simple-icons/blob/develop/CONTRIBUTING.md
-->

**Issue:**


### Checklist
  - [ ] I updated the JSON data in `_data/simple-icons.json`
  - [ ] I optimized the icon with SVGO or SVGOMG
  - [ ] The SVG `viewbox` is `0 0 24 24`

### Description
<!--
Anything relevant, for example:
  - Why did you pick the hex value?
  - Did you manually vectorize the logo?
  - Have you used multiple sources?
  - etc.
-->
